### PR TITLE
add unit test skeleton with smoke test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,3 +15,12 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v5
       - run: uvx mypy .
+  unittest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+      - run: python3 -m unittest

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+import sys
+
+# Ensure secp256k1lab is found and can be imported directly
+sys.path.insert(0, str(Path(__file__).parent / "../src/"))

--- a/test/test_bip340.py
+++ b/test/test_bip340.py
@@ -1,0 +1,18 @@
+from random import randbytes
+import unittest
+
+from secp256k1lab.bip340 import pubkey_gen, schnorr_sign, schnorr_verify
+
+
+class BIP340Tests(unittest.TestCase):
+    """Test schnorr signatures (BIP 340)."""
+    # TODO: test against testvectors (see https://github.com/secp256k1lab/secp256k1lab/issues/1)
+
+    def test_correctness(self):
+        seckey = randbytes(32)
+        pubkey_xonly = pubkey_gen(seckey)
+        aux_rand = randbytes(32)
+        message = b'this is some arbitrary message'
+        signature = schnorr_sign(message, seckey, aux_rand)
+        success = schnorr_verify(message, pubkey_xonly, signature)
+        self.assertTrue(success)

--- a/test/test_ecdh.py
+++ b/test/test_ecdh.py
@@ -1,0 +1,18 @@
+from random import randbytes
+import unittest
+
+from secp256k1lab.ecdh import ecdh_libsecp256k1
+from secp256k1lab.keys import pubkey_gen_plain
+
+
+class ECDHTests(unittest.TestCase):
+    """Test ECDH module."""
+
+    def test_correctness(self):
+        seckey_alice = randbytes(32)
+        pubkey_alice = pubkey_gen_plain(seckey_alice)
+        seckey_bob = randbytes(32)
+        pubkey_bob = pubkey_gen_plain(seckey_bob)
+        shared_secret1 = ecdh_libsecp256k1(seckey_alice, pubkey_bob)
+        shared_secret2 = ecdh_libsecp256k1(seckey_bob, pubkey_alice)
+        self.assertEqual(shared_secret1, shared_secret2)


### PR DESCRIPTION
This PR adds a sample unit test, with the side goal of starting a discussion on how to best integrate them in the project and if we want to use a unit test framework (like e.g. [unittest](https://docs.python.org/3/library/unittest.html) or [pytest](https://docs.pytest.org/en/stable/)).