### PR TITLE
ci: run tests with multiple Python versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,13 @@ jobs:
       - run: uvx mypy .
   unittest:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Python
+      - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
       - run: python3 -m unittest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,15 @@ jobs:
       - run: uvx ruff check .
   mypy:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
-      - name: Install the latest version of uv
+      - name: Install the latest version of uv, setup Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - run: uvx mypy .
   unittest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As suggested in issue #4, run the tests on every Python version starting from the minimum supported one, i.e. versions 3.9, 3.10, 3.11, 3.12 and 3.13. This is done by using matrix testing, see e.g. https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#matrix-testing