### PR TITLE
Scalar: add non-zero checking constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+#### Added
+ - Added new methods `Scalar.from_int_nonzero_checked` and `Scalar.from_bytes_nonzero_checked`
+   that ensure a constructed scalar is in the range `0 < s < N` (i.e. is non-zero and within the
+   group order) and throw a `ValueError` otherwise. This is e.g. useful for ensuring that newly
+   generated secret keys or nonces are valid without having to do the non-zero check manually.
+   The already existing methods `Scalar.from_int_checked` and `Scalar.from_bytes_checked` error
+   on overflow, but not on zero, i.e. they only ensure `0 <= s < N`.
+
 ## [1.0.0] - 2025-03-31
 
 Initial release.

--- a/src/secp256k1lab/secp256k1.py
+++ b/src/secp256k1lab/secp256k1.py
@@ -192,6 +192,19 @@ class Scalar(APrimeFE):
     """TODO Docstring"""
     SIZE = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
 
+    @classmethod
+    def from_int_nonzero_checked(cls, v):
+        """Convert an integer to a scalar (no zero or overflow allowed)."""
+        if not (0 < v < cls.SIZE):
+            raise ValueError
+        return cls(v)
+
+    @classmethod
+    def from_bytes_nonzero_checked(cls, b):
+        """Convert a 32-byte array to a scalar (BE byte order, no zero or overflow allowed)."""
+        v = int.from_bytes(b, 'big')
+        return cls.from_int_nonzero_checked(v)
+
 
 class GE:
     """Objects of this class represent secp256k1 group elements (curve points or infinity)

--- a/test/test_secp256k1.py
+++ b/test/test_secp256k1.py
@@ -1,0 +1,77 @@
+"""Test low-level secp256k1 field and group arithmetic classes."""
+from random import randint
+import unittest
+
+from secp256k1lab.secp256k1 import FE, Scalar
+
+
+class PrimeFieldTests(unittest.TestCase):
+    def test_fe_constructors(self):
+        P = FE.SIZE
+        random_fe_valid = randint(0, P-1)
+        random_fe_overflowing = randint(P, 2**256-1)
+
+        # wrapping constructors
+        for init_value in [0, P-1, P, P+1, random_fe_valid, random_fe_overflowing]:
+            fe1 = FE(init_value)
+            fe2 = FE.from_int_wrapping(init_value)
+            fe3 = FE.from_bytes_wrapping(init_value.to_bytes(32, 'big'))
+            reduced_value = init_value % P
+            self.assertEqual(int(fe1), reduced_value)
+            self.assertEqual(int(fe1), int(fe2))
+            self.assertEqual(int(fe2), int(fe3))
+
+        # checking constructors (should throw on overflow)
+        for valid_value in [0, P-1, random_fe_valid]:
+            fe1 = FE.from_int_checked(valid_value)
+            fe2 = FE.from_bytes_checked(valid_value.to_bytes(32, 'big'))
+            self.assertEqual(int(fe1), valid_value)
+            self.assertEqual(int(fe1), int(fe2))
+
+        for overflow_value in [P, P+1, random_fe_overflowing]:
+            with self.assertRaises(ValueError):
+                _ = FE.from_int_checked(overflow_value)
+            with self.assertRaises(ValueError):
+                _ = FE.from_bytes_checked(overflow_value.to_bytes(32, 'big'))
+
+    def test_scalar_constructors(self):
+        N = Scalar.SIZE
+        random_scalar_valid = randint(0, N-1)
+        random_scalar_overflowing = randint(N, 2**256-1)
+
+        # wrapping constructors
+        for init_value in [0, N-1, N, N+1, random_scalar_valid, random_scalar_overflowing]:
+            s1 = Scalar(init_value)
+            s2 = Scalar.from_int_wrapping(init_value)
+            s3 = Scalar.from_bytes_wrapping(init_value.to_bytes(32, 'big'))
+            reduced_value = init_value % N
+            self.assertEqual(int(s1), reduced_value)
+            self.assertEqual(int(s1), int(s2))
+            self.assertEqual(int(s2), int(s3))
+
+        # checking constructors (should throw on overflow)
+        for valid_value in [0, N-1, random_scalar_valid]:
+            s1 = Scalar.from_int_checked(valid_value)
+            s2 = Scalar.from_bytes_checked(valid_value.to_bytes(32, 'big'))
+            self.assertEqual(int(s1), valid_value)
+            self.assertEqual(int(s1), int(s2))
+
+        for overflow_value in [N, N+1, random_scalar_overflowing]:
+            with self.assertRaises(ValueError):
+                _ = Scalar.from_int_checked(overflow_value)
+            with self.assertRaises(ValueError):
+                _ = Scalar.from_bytes_checked(overflow_value.to_bytes(32, 'big'))
+
+        # non-zero checking constructors (should throw on zero or overflow, only for Scalar)
+        random_nonzero_scalar_valid = randint(1, N-1)
+        for valid_value in [1, N-1, random_nonzero_scalar_valid]:
+            s1 = Scalar.from_int_nonzero_checked(valid_value)
+            s2 = Scalar.from_bytes_nonzero_checked(valid_value.to_bytes(32, 'big'))
+            self.assertEqual(int(s1), valid_value)
+            self.assertEqual(int(s1), int(s2))
+
+        for invalid_value in [0, N, random_scalar_overflowing]:
+            with self.assertRaises(ValueError):
+                _ = Scalar.from_int_nonzero_checked(invalid_value)
+            with self.assertRaises(ValueError):
+                _ = Scalar.from_bytes_nonzero_checked(invalid_value.to_bytes(32, 'big'))


### PR DESCRIPTION
As suggested in #7, this PR adds checking constructors for the `Scalar` class that ensure that the passed values are in range `[1..SIZE-1]` (stricter than the already existing checking constructors that allow `[0..SIZE-1]`), i.e. an exception is thrown both on overflow and zero values. This can be useful for e.g. representing secret keys and nonces. The second commit adds a unit test for FE and Scalar constructors (happy to receive feedback, particularly about test naming and organization; maybe some deduplication makes sense?).

Closes #7.

(This PR should be rebased if https://github.com/secp256k1lab/secp256k1lab/pull/11 goes in first, as they conflict with the introduced test file test_secp256k1.py.)