### PR TITLE
Introduce `GE.from_bytes_with_infinity` method

### DIFF
--- a/src/secp256k1lab/secp256k1.py
+++ b/src/secp256k1lab/secp256k1.py
@@ -368,6 +368,14 @@ class GE:
         return r
 
     @staticmethod
+    def from_bytes_compressed_with_infinity(b):
+        """Convert a compressed to a group element, mapping zeros to infinity."""
+        if b == 33 * b"\x00":
+            return GE()
+        else:
+            return GE.from_bytes_compressed(b)
+
+    @staticmethod
     def from_bytes_uncompressed(b):
         """Convert an uncompressed to a group element."""
         assert len(b) == 65


### PR DESCRIPTION
I'm working on [adding serialization/deserialization methods to ChillDKG](https://github.com/BlockstreamResearch/bip-frost-dkg/pull/88) and need a helper function for deserializing coordinator messages. The function I need would map the 33 zero bytes to the infinity point.

For context: https://github.com/BlockstreamResearch/bip-frost-dkg/pull/88#discussion_r2056790980

I named the method `from_bytes_with_infinity` to match the existing `to_bytes_with_infinity` method in GE, but `from_zero_bytes` might be a more accurate name.