### PR TITLE
Add runnable ECDH and Schnorr (BIP340) examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+# secp256k1lab examples
+
+This folder contains small, **self-contained** runnable examples, modeled after
+libsecp256k1's C examples.
+
+## Run (no installation required)
+
+From the repository root:
+
+```bash
+python -m examples ecdh
+python -m examples schnorr
+

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,7 @@
+"""Runnable examples for secp256k1lab.
+
+You can run these from a source checkout without installing the package:
+  python -m examples ecdh
+  python -m examples schnorr
+"""
+

--- a/examples/__main__.py
+++ b/examples/__main__.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Dispatcher for the examples package.
+
+Usage:
+  python -m examples ecdh
+  python -m examples schnorr
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import argparse
+import sys
+
+
+# Make `src/` importable when running from a source checkout (no pip install needed).
+_ROOT = Path(__file__).resolve().parents[1]
+_SRC = _ROOT / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="python -m examples")
+    p.add_argument(
+        "example",
+        choices=["ecdh", "schnorr"],
+        help="Which example to run",
+    )
+    return p
+
+
+def main(argv=None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    if args.example == "ecdh":
+        from . import ecdh as mod
+    else:
+        from . import schnorr as mod
+
+    return int(mod.main())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/examples/ecdh.py
+++ b/examples/ecdh.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""ECDH example (Python)
+
+This mirrors the libsecp256k1 C example at:
+  https://github.com/bitcoin-core/secp256k1/blob/master/examples/ecdh.c
+
+Run from the project root (no installation required):
+  python examples/ecdh.py
+
+Or:
+  python -m examples ecdh
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import secrets
+import sys
+
+
+# Make `src/` importable when running from a source checkout (no pip install needed).
+_ROOT = Path(__file__).resolve().parents[1]
+_SRC = _ROOT / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+
+from secp256k1lab.ecdh import ecdh_libsecp256k1
+from secp256k1lab.keys import pubkey_gen_plain
+from secp256k1lab.secp256k1 import GE
+
+
+def _rand_seckey() -> bytes:
+    """Return a valid 32-byte secp256k1 secret key (1..n-1)."""
+    d = secrets.randbelow(GE.ORDER - 1) + 1
+    return d.to_bytes(32, byteorder="big")
+
+
+def _print_hex_line(label: str, b: bytes) -> None:
+    print(f"{label}{b.hex()}")
+
+
+def main() -> int:
+    # Key generation (two parties).
+    seckey1 = _rand_seckey()
+    seckey2 = _rand_seckey()
+
+    pubkey1 = pubkey_gen_plain(seckey1)  # 33-byte compressed pubkey
+    pubkey2 = pubkey_gen_plain(seckey2)
+
+    # ECDH shared secret (libsecp256k1 default: SHA256(compressed(shared_point))).
+    shared_secret1 = ecdh_libsecp256k1(seckey1, pubkey2)
+    shared_secret2 = ecdh_libsecp256k1(seckey2, pubkey1)
+
+    # Both parties should end up with the same shared secret.
+    assert shared_secret1 == shared_secret2
+
+    _print_hex_line("Secret Key1: ", seckey1)
+    _print_hex_line("Compressed Pubkey1: ", pubkey1)
+    print()
+    _print_hex_line("Secret Key2: ", seckey2)
+    _print_hex_line("Compressed Pubkey2: ", pubkey2)
+    print()
+    _print_hex_line("Shared Secret: ", shared_secret1)
+
+    # Note: In C you can securely erase sensitive buffers. Python can't guarantee this
+    # for immutable `bytes` objects; treat this example as educational only.
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/examples/schnorr.py
+++ b/examples/schnorr.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Schnorr (BIP340) example (Python)
+
+This mirrors the libsecp256k1 C example at:
+  https://github.com/bitcoin-core/secp256k1/blob/master/examples/schnorr.c
+
+Run from the project root (no installation required):
+  python examples/schnorr.py
+
+Or:
+  python -m examples schnorr
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import secrets
+import sys
+
+
+# Make `src/` importable when running from a source checkout (no pip install needed).
+_ROOT = Path(__file__).resolve().parents[1]
+_SRC = _ROOT / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+
+from secp256k1lab.bip340 import pubkey_gen, schnorr_sign, schnorr_verify
+from secp256k1lab.secp256k1 import GE
+from secp256k1lab.util import tagged_hash
+
+
+def _rand_seckey() -> bytes:
+    """Return a valid 32-byte secp256k1 secret key (1..n-1)."""
+    d = secrets.randbelow(GE.ORDER - 1) + 1
+    return d.to_bytes(32, byteorder="big")
+
+
+def _print_hex_line(label: str, b: bytes) -> None:
+    print(f"{label}{b.hex()}")
+
+
+def main() -> int:
+    # Message and "protocol tag" (domain separation).
+    msg = b"Hello World!"
+    tag = "my_fancy_protocol"
+
+    # Sign a 32-byte tagged SHA256 hash of the message.
+    msg_hash = tagged_hash(tag, msg)
+    assert len(msg_hash) == 32
+
+    # Key generation.
+    seckey = _rand_seckey()
+    pubkey_xonly = pubkey_gen(seckey)  # 32-byte x-only pubkey
+
+    # BIP340 recommends 32 bytes of auxiliary randomness.
+    aux_rand = secrets.token_bytes(32)
+
+    # Sign and verify.
+    signature = schnorr_sign(msg_hash, seckey, aux_rand)
+    is_valid = schnorr_verify(msg_hash, pubkey_xonly, signature)
+
+    print(f"Is the signature valid? {'true' if is_valid else 'false'}")
+    _print_hex_line("Secret Key: ", seckey)
+    _print_hex_line("Public Key: ", pubkey_xonly)
+    _print_hex_line("Signature: ", signature)
+
+    return 0 if is_valid else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
This PR adds a new `examples/` folder with small, self-contained runnable examples modeled after libsecp256k1’s C examples (ECDH and Schnorr/BIP340). Examples can be run from a source checkout with no installation required:

* `python -m examples ecdh` / `python -m examples schnorr`
* or directly: `python examples/ecdh.py` / `python examples/schnorr.py`

This is intended to help users to understand the library better.