### PR TITLE
reject wrong-length and off-curve input at the parse boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    point at infinity. This is the counterpart to the already existing serialization
    method `GE.to_bytes_compressed_with_infinity`.
 
+#### Changed
+ - The field and scalar byte constructors (`from_bytes_checked`, `from_bytes_wrapping`,
+   `from_bytes_nonzero_checked`) reject any input that is not exactly 32 bytes with a
+   `ValueError`. The group-element parsers (`GE.from_bytes*`) and the curve-membership
+   check in `GE.__init__` raise `ValueError` rather than `assert`, so these checks also
+   hold under `python -O`.
+
 ## [1.0.0] - 2025-03-31
 
 Initial release.

--- a/src/secp256k1lab/secp256k1.py
+++ b/src/secp256k1lab/secp256k1.py
@@ -155,12 +155,16 @@ class APrimeFE:
     @classmethod
     def from_bytes_checked(cls, b: bytes) -> Self:
         """Convert a 32-byte array to a field element (BE byte order, no overflow allowed)."""
+        if len(b) != 32:
+            raise ValueError
         v = int.from_bytes(b, 'big')
         return cls.from_int_checked(v)
 
     @classmethod
     def from_bytes_wrapping(cls, b: bytes) -> Self:
         """Convert a 32-byte array to a field element (BE byte order, reduced modulo SIZE)."""
+        if len(b) != 32:
+            raise ValueError
         v = int.from_bytes(b, 'big')
         return cls.from_int_wrapping(v)
 
@@ -208,6 +212,8 @@ class Scalar(APrimeFE):
     @classmethod
     def from_bytes_nonzero_checked(cls, b: bytes) -> Self:
         """Convert a 32-byte array to a scalar (BE byte order, no zero or overflow allowed)."""
+        if len(b) != 32:
+            raise ValueError
         v = int.from_bytes(b, 'big')
         return cls.from_int_nonzero_checked(v)
 
@@ -265,7 +271,8 @@ class GE:
             assert y is not None
             fx = FE(x)
             fy = FE(y)
-            assert fy**2 == fx**3 + 7
+            if fy**2 != fx**3 + 7:
+                raise ValueError
             self._infinity = False
             self._x = fx
             self._y = fy
@@ -381,7 +388,8 @@ class GE:
     @staticmethod
     def from_bytes_compressed(b: bytes) -> GE:
         """Convert a compressed to a group element."""
-        assert len(b) == 33
+        if len(b) != 33:
+            raise ValueError
         if b[0] != 2 and b[0] != 3:
             raise ValueError
         x = FE.from_bytes_checked(b[1:])
@@ -401,7 +409,8 @@ class GE:
     @staticmethod
     def from_bytes_uncompressed(b: bytes) -> GE:
         """Convert an uncompressed to a group element."""
-        assert len(b) == 65
+        if len(b) != 65:
+            raise ValueError
         if b[0] != 4:
             raise ValueError
         x = FE.from_bytes_checked(b[1:33])
@@ -413,7 +422,8 @@ class GE:
     @staticmethod
     def from_bytes(b: bytes) -> GE:
         """Convert a compressed or uncompressed encoding to a group element."""
-        assert len(b) in (33, 65)
+        if len(b) not in (33, 65):
+            raise ValueError
         if len(b) == 33:
             return GE.from_bytes_compressed(b)
         else:
@@ -422,7 +432,8 @@ class GE:
     @staticmethod
     def from_bytes_xonly(b: bytes) -> GE:
         """Convert a point given in xonly encoding to a group element."""
-        assert len(b) == 32
+        if len(b) != 32:
+            raise ValueError
         x = FE.from_bytes_checked(b)
         r = GE.lift_x(x)
         return r

--- a/test/test_secp256k1.py
+++ b/test/test_secp256k1.py
@@ -78,6 +78,21 @@ class PrimeFieldTests(unittest.TestCase):
                 _ = Scalar.from_bytes_nonzero_checked(invalid_value.to_bytes(32, 'big'))
 
 
+    def test_from_bytes_rejects_wrong_length(self):
+        # The byte constructors document a 32-byte input. Any other length must
+        # be rejected rather than silently reinterpreted as a shorter or longer
+        # integer. Each input below encodes a small in-range value, so length is
+        # the only possible cause of rejection.
+        ctors = [FE.from_bytes_checked, FE.from_bytes_wrapping,
+                 Scalar.from_bytes_checked, Scalar.from_bytes_wrapping,
+                 Scalar.from_bytes_nonzero_checked]
+        for length in (0, 1, 31, 33, 64):
+            b = b'\x00' * (length - 1) + b'\x01' if length else b''
+            for ctor in ctors:
+                with self.assertRaises(ValueError):
+                    ctor(b)
+
+
 class GeSerializationTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -179,6 +194,31 @@ class GeSerializationTests(unittest.TestCase):
                 self.assertEqual(ge_ser[0], 0x02 if ge_orig.has_even_y() else 0x03)
             ge_deser = GE.from_bytes_compressed_with_infinity(ge_ser)
             self.assertEqual(ge_deser, ge_orig)
+
+
+    def test_from_bytes_rejects_wrong_length(self):
+        # Parsing must reject a wrong-length encoding with an exception, and one
+        # that survives `python -O` (ValueError), not a bare assert.
+        ge = self.group_elements_on_curve[0]
+        comp = ge.to_bytes_compressed()      # 33 bytes
+        uncomp = ge.to_bytes_uncompressed()  # 65 bytes
+        xonly = ge.to_bytes_xonly()          # 32 bytes
+        for good, parse in ((comp, GE.from_bytes_compressed),
+                            (uncomp, GE.from_bytes_uncompressed),
+                            (xonly, GE.from_bytes_xonly)):
+            for bad in (good + b'\x00', good[:-1]):
+                with self.assertRaises(ValueError):
+                    parse(bad)
+        # the length dispatcher rejects anything that is neither 33 nor 65 bytes
+        for bad in (b'', xonly, comp + b'\x00', uncomp + b'\x00'):
+            with self.assertRaises(ValueError):
+                GE.from_bytes(bad)
+
+    def test_init_off_curve_raises(self):
+        # (1, 1) does not satisfy y**2 = x**3 + 7. Construction must be rejected,
+        # again with an exception that survives `python -O`.
+        with self.assertRaises(ValueError):
+            GE(1, 1)
 
 
 class GeArithmeticTests(unittest.TestCase):


### PR DESCRIPTION
The byte constructors for field elements and scalars are documented as taking a 32-byte array but never checked the length, so a shorter or longer buffer was silently reinterpreted as an in-range value. The group-element parsers and the curve-membership check in `GE.__init__` enforced their preconditions with `assert`, which `python -O` strips.

This adds length checks to `from_bytes_checked`, `from_bytes_wrapping` and `from_bytes_nonzero_checked`, and raises `ValueError` instead of asserting at each parse boundary and in the curve-membership check, so rejection also holds under `python -O`. Tests cover each rejection.
