### PR TITLE
ecdh: reject zero secret key at the input boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    point at infinity. This is the counterpart to the already existing serialization
    method `GE.to_bytes_compressed_with_infinity`.
 
+#### Fixed
+ - `ecdh_compressed_in_raw_out` now rejects a zero secret key with a `ValueError` at the input
+   boundary, instead of failing later with an `AssertionError`.
+
 ## [1.0.0] - 2025-03-31
 
 Initial release.

--- a/src/secp256k1lab/ecdh.py
+++ b/src/secp256k1lab/ecdh.py
@@ -4,13 +4,16 @@ from .secp256k1 import GE, Scalar
 
 
 def ecdh_compressed_in_raw_out(seckey: bytes, pubkey: bytes) -> GE:
-    """TODO"""
-    shared_secret = Scalar.from_bytes_checked(seckey) * GE.from_bytes_compressed(pubkey)
-    assert not shared_secret.infinity  # prime-order group
+    """Compute the ECDH shared secret point from a secret key and a compressed public key."""
+    shared_secret = Scalar.from_bytes_nonzero_checked(seckey) * GE.from_bytes_compressed(pubkey)
+    # Write x = seckey and y = dlog(pubkey). Then x != 0 and y != 0
+    # imply x*y != 0 because the scalar group has prime order and thus
+    # is a finite field (it has the same order as secp256k1).
+    assert not shared_secret.infinity
     return shared_secret
 
 
 def ecdh_libsecp256k1(seckey: bytes, pubkey: bytes) -> bytes:
-    """TODO"""
+    """Compute the ECDH shared secret as libsecp256k1 does: SHA256 of the compressed shared point."""
     shared_secret = ecdh_compressed_in_raw_out(seckey, pubkey)
     return hashlib.sha256(shared_secret.to_bytes_compressed()).digest()

--- a/test/test_ecdh.py
+++ b/test/test_ecdh.py
@@ -1,7 +1,7 @@
 import unittest
 from random import randbytes
 
-from secp256k1lab.ecdh import ecdh_libsecp256k1
+from secp256k1lab.ecdh import ecdh_compressed_in_raw_out, ecdh_libsecp256k1
 from secp256k1lab.keys import pubkey_gen_plain
 
 
@@ -28,3 +28,9 @@ class ECDHTests(unittest.TestCase):
             "80a9f99957b29af20338037cf06360bc55422e5bba0032bb4136498c278a7db1"
         )
         self.assertEqual(ecdh_libsecp256k1(seckey_a, pubkey_b), expected)
+
+    def test_zero_seckey(self):
+        pubkey = pubkey_gen_plain(randbytes(32))
+        zero_seckey = b'\x00' * 32
+        self.assertRaises(ValueError, ecdh_compressed_in_raw_out, zero_seckey, pubkey)
+        self.assertRaises(ValueError, ecdh_libsecp256k1, zero_seckey, pubkey)


### PR DESCRIPTION
`ecdh_compressed_in_raw_out` parsed the secret key with `Scalar.from_bytes_checked`, which allows zero. A zero secret key then reached `assert not shared_secret.infinity` and surfaced as an `AssertionError` on an unrelated invariant rather than being rejected at the input boundary.

This parses the secret key with `Scalar.from_bytes_nonzero_checked`, so a zero key is rejected with `ValueError` at the boundary. The infinity assert is kept as a documented prime-order-group invariant, now unreachable for a non-zero scalar. The two placeholder docstrings are filled in, and a test covers the zero-key rejection.
