### PR TITLE
test: add ecdh known-answer test

### DIFF
--- a/test/test_ecdh.py
+++ b/test/test_ecdh.py
@@ -16,3 +16,15 @@ class ECDHTests(unittest.TestCase):
         shared_secret1 = ecdh_libsecp256k1(seckey_alice, pubkey_bob)
         shared_secret2 = ecdh_libsecp256k1(seckey_bob, pubkey_alice)
         self.assertEqual(shared_secret1, shared_secret2)
+
+    def test_known_answer(self):
+        # Vector cross-checked against libsecp256k1's default ECDH, which
+        # hashes the compressed shared point with SHA256.
+        seckey_a = bytes.fromhex("01" * 32)
+        pubkey_b = bytes.fromhex(
+            "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
+        )
+        expected = bytes.fromhex(
+            "80a9f99957b29af20338037cf06360bc55422e5bba0032bb4136498c278a7db1"
+        )
+        self.assertEqual(ecdh_libsecp256k1(seckey_a, pubkey_b), expected)


### PR DESCRIPTION
The ECDH module's only test was a symmetry check; nothing pinned an expected value, so an implementation that hashed the uncompressed shared point instead of the compressed one would pass unchanged.

This adds a known-answer test with fixed private keys and an expected shared secret, cross-checked against libsecp256k1's default ECDH (SHA256 of the compressed shared point).
