### PR TITLE
lint: make ruff check pass

### DIFF
--- a/src/secp256k1lab/bip340.py
+++ b/src/secp256k1lab/bip340.py
@@ -2,7 +2,7 @@
 # https://github.com/bitcoin/bips/blob/master/bip-0340/reference.py
 
 from .secp256k1 import FE, GE, G
-from .util import int_from_bytes, bytes_from_int, xor_bytes, tagged_hash
+from .util import bytes_from_int, int_from_bytes, tagged_hash, xor_bytes
 
 
 def pubkey_gen(seckey: bytes) -> bytes:
@@ -21,7 +21,7 @@ def schnorr_sign(
     if not (1 <= d0 <= GE.ORDER - 1):
         raise ValueError("The secret key must be an integer in the range 1..n-1.")
     if len(aux_rand) != 32:
-        raise ValueError("aux_rand must be 32 bytes instead of %i." % len(aux_rand))
+        raise ValueError(f"aux_rand must be 32 bytes instead of {len(aux_rand)}.")
     P = d0 * G
     assert not P.infinity
     d = d0 if P.has_even_y() else GE.ORDER - d0
@@ -68,6 +68,4 @@ def schnorr_verify(
         % GE.ORDER
     )
     R = s * G - e * P
-    if R.infinity or (not R.has_even_y()) or (R.x != r):
-        return False
-    return True
+    return not (R.infinity or (not R.has_even_y()) or (R.x != r))

--- a/src/secp256k1lab/secp256k1.py
+++ b/src/secp256k1lab/secp256k1.py
@@ -16,7 +16,9 @@ Exports:
 """
 
 from __future__ import annotations
+
 from typing import Self
+
 
 # TODO Docstrings of methods still say "field element"
 class APrimeFE:
@@ -94,7 +96,7 @@ class APrimeFE:
 
     def __truediv__(self, a: int | Self) -> Self:
         """Compute the ratio of two field elements (second may be int)."""
-        if isinstance(a, type(self)) or isinstance(a, int):
+        if isinstance(a, (type(self), int)):
             return type(self)(self, a)
         return NotImplemented
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 
 # Ensure secp256k1lab is found and can be imported directly
 sys.path.insert(0, str(Path(__file__).parent / "../src/"))

--- a/test/test_bip340.py
+++ b/test/test_bip340.py
@@ -1,7 +1,7 @@
 import csv
+import unittest
 from pathlib import Path
 from random import randbytes
-import unittest
 
 from secp256k1lab.bip340 import pubkey_gen, schnorr_sign, schnorr_verify
 

--- a/test/test_ecdh.py
+++ b/test/test_ecdh.py
@@ -1,5 +1,5 @@
-from random import randbytes
 import unittest
+from random import randbytes
 
 from secp256k1lab.ecdh import ecdh_libsecp256k1
 from secp256k1lab.keys import pubkey_gen_plain

--- a/test/test_secp256k1.py
+++ b/test/test_secp256k1.py
@@ -1,8 +1,8 @@
 """Test low-level secp256k1 field and group arithmetic classes."""
-from random import randint
 import unittest
+from random import randint
 
-from secp256k1lab.secp256k1 import FE, G, GE, Scalar
+from secp256k1lab.secp256k1 import FE, GE, G, Scalar
 
 
 class PrimeFieldTests(unittest.TestCase):


### PR DESCRIPTION
CI's `ruff` job (`uvx ruff check .`, unpinned) fails on master under ruff 0.16.6 with 9 errors, while every other job (unittest 3.11–3.14, mypy) is green. This makes them pass, with no behavior change:

- import sorting (I001) in the two source modules and the four test files;
- `bip340.py`: an f-string in place of `%`-formatting for one `ValueError` message;
- `bip340.py`: `schnorr_verify` returns the negated condition directly instead of `if …: return False` / `return True`;
- `secp256k1.py`: the two `isinstance` calls in `__truediv__` merged into one.

All behavior-preserving; unittest and mypy stay green.
